### PR TITLE
Fix relay lib

### DIFF
--- a/broker/broker.go
+++ b/broker/broker.go
@@ -8,6 +8,7 @@ type Broker interface {
 	Close() error
 	Consumer(queue string) (Consumer, error)
 	Publisher(queue string) (Publisher, error)
+	PublisherWithRoutingKey(queue string, routingKey string) (Publisher, error)
 }
 
 // Publisher is used to push messages into a queue

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,8 @@
+module github.com/WinnerSoftLab/relay
+
+go 1.13
+
+require (
+	github.com/hashicorp/go-uuid v1.0.2
+	github.com/streadway/amqp v1.0.0
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,4 @@
+github.com/hashicorp/go-uuid v1.0.2 h1:cfejS+Tpcp13yd5nYHWDI6qVCny6wyX2Mt5SGur2IGE=
+github.com/hashicorp/go-uuid v1.0.2/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
+github.com/streadway/amqp v1.0.0 h1:kuuDrUJFZL1QYL9hUNuCxNObNzB0bV/ZG5jV3RWAQgo=
+github.com/streadway/amqp v1.0.0/go.mod h1:AZpEONHx3DKn8O/DFsRAY58/XVQiIPMTMB1SddzLXVw=

--- a/relay.go
+++ b/relay.go
@@ -6,8 +6,9 @@ import (
 	"sync"
 	"time"
 
-	"github.com/WinnerSoftLab/relay/broker"
 	"github.com/streadway/amqp"
+
+	"github.com/WinnerSoftLab/relay/broker"
 )
 
 // Config is passed into New when creating a Relay to tune
@@ -334,10 +335,12 @@ func (r *Relay) PublisherWithRoutingKey(queue string, routingKey string) (*Publi
 		}
 	}()
 
-	// Ensure the queue exists
 	name := queueName(queue, r.conf.WithoutPrefix)
-	if err := r.declareQueue(ch, name, routingKey); err != nil {
-		return nil, err
+	if queue != "" { // do not create exclusive queue for publisher w/o consumers
+		// Ensure the queue exists
+		if err := r.declareQueue(ch, name, routingKey); err != nil {
+			return nil, err
+		}
 	}
 
 	// Determine content type
@@ -388,6 +391,10 @@ func (r *relayBroker) Close() error {
 
 func (r *relayBroker) Publisher(q string) (broker.Publisher, error) {
 	return r.relay.Publisher(q)
+}
+
+func (r *relayBroker) PublisherWithRoutingKey(queue string, routingKey string) (broker.Publisher, error) {
+	return r.relay.PublisherWithRoutingKey(queue, routingKey)
 }
 
 func (r *relayBroker) Consumer(q string) (broker.Consumer, error) {


### PR DESCRIPTION
1. Do not create an exclusive queue for the publisher (useless queue w/o any consumers)
2. Allow to create publisher without queue but with routing key (or with routing key != queue name)
3. Add go.mod for future delivery switching from dep to mod